### PR TITLE
Feature: Add support for multiple breakglass accounts

### DIFF
--- a/collect_setup/collector_config.sample
+++ b/collect_setup/collector_config.sample
@@ -63,8 +63,8 @@ export CA_ISSUERS="Let's Encrypt,Verisign"
 export ORG_ID="1234567890"
 
 #GR13.2 & GR13.3
-# breakglass user email
-export BREAKGLASS_USER_EMAIL="breakglass-account@example.com"
+# breakglass user emails
+export BREAKGLASS_USER_EMAILS='["breakglass-account@example.com"]'
 
 
 

--- a/collect_setup/collector_setup.sh
+++ b/collect_setup/collector_setup.sh
@@ -58,7 +58,7 @@ function config_init {
 
   ## Gathers required information for installation
   printf "$LANG_SETUP_PROMPT"
-  REQUIRED_VARIABLES=("PROJECT_ID" "SERVICE_ACCOUNT" "ORG_NAME" "GC_PROFILE" "SECURITY_CATEGORY_KEY" "PRIVILEGED_USERS_LIST" "REGULAR_USERS_LIST" "ALLOWED_DOMAINS" "DENY_DOMAINS" "HAS_GUEST_USERS" "HAS_FEDERATED_USERS" "ALLOWED_IPS" "CUSTOMER_IDS" "CA_ISSUERS" "ORG_ADMIN_GROUP_EMAIL" "BREAKGLASS_USER_EMAIL" "SSC_BUCKET_NAME" "POLICY_REPO" "OPA_IMAGE" "REGION")
+  REQUIRED_VARIABLES=("PROJECT_ID" "SERVICE_ACCOUNT" "ORG_NAME" "GC_PROFILE" "SECURITY_CATEGORY_KEY" "PRIVILEGED_USERS_LIST" "REGULAR_USERS_LIST" "ALLOWED_DOMAINS" "DENY_DOMAINS" "HAS_GUEST_USERS" "HAS_FEDERATED_USERS" "ALLOWED_IPS" "CUSTOMER_IDS" "CA_ISSUERS" "ORG_ADMIN_GROUP_EMAIL" "BREAKGLASS_USER_EMAILS" "SSC_BUCKET_NAME" "POLICY_REPO" "OPA_IMAGE" "REGION")
 
   for setting in "${REQUIRED_VARIABLES[@]}"; do
     if [[ "$setting" == "ALLOWED_IPS" && $HAS_FEDERATED_USERS == "true" ]]; then
@@ -224,8 +224,8 @@ function cloudrun_service {
                   value: "${DIRECTORY_CUSTOMER_ID}"
                 - name: ORG_ADMIN_GROUP_EMAIL
                   value: "${ORG_ADMIN_GROUP_EMAIL}"
-                - name: BREAKGLASS_USER_EMAIL
-                  value: "${BREAKGLASS_USER_EMAIL}"
+                - name: BREAKGLASS_USER_EMAILS
+                  value: "${BREAKGLASS_USER_EMAILS}"
                 resources:
                   limits:
                     cpu: 4000m
@@ -277,10 +277,10 @@ function cloudrun_service {
                   value: "${SECURITY_CATEGORY_KEY}"
                 - name: GR07_03_ALLOWED_CA_ISSUERS
                   value: "${CA_ISSUERS}"
-                - name: GR13_02_BREAKGLASS_USER_EMAIL
-                  value: "${BREAKGLASS_USER_EMAIL}"
-                - name: GR13_03_BREAKGLASS_USER_EMAIL
-                  value: "${BREAKGLASS_USER_EMAIL}"
+                - name: GR13_02_BREAKGLASS_USER_EMAILS
+                  value: "${BREAKGLASS_USER_EMAILS}"
+                - name: GR13_03_BREAKGLASS_USER_EMAILS
+                  value: "${BREAKGLASS_USER_EMAILS}"
                 resources:
                   limits:
                     cpu: 4000m


### PR DESCRIPTION
Changes have been made to incorporate a feature to support having multiple breakglass accounts.

Majority of the work is in reconfiguring the environment variables that need to be passed to Cloud Run for the policies to properly work.