### PR TITLE
Fix: Replace GCP Pre-defined roles with custom roles

### DIFF
--- a/collect_setup/collector_setup.sh
+++ b/collect_setup/collector_setup.sh
@@ -199,7 +199,7 @@ function storage_bucket {
   RUN_HOUR="02:00:00-04:00"
   ORDINAL=$((($RANDOM % 10 + 1)))
 
-  Set up cloud storage transfer job
+  # Set up cloud storage transfer job
   gcloud transfer jobs list --job-statuses=enabled | grep nightly_compliance_transfer >/dev/null 2>&1
   ret=$?
   if [ $ret -ne 0 ]; then

--- a/collect_setup/collector_setup.sh
+++ b/collect_setup/collector_setup.sh
@@ -6,7 +6,20 @@
 set -o pipefail
 
 ## declare an array of policies
-declare -a ROLES=("roles/iam.workloadIdentityUser" "roles/run.developer" "roles/iam.serviceAccountUser" "roles/storage.admin" "roles/cloudscheduler.admin" "roles/run.invoker" "roles/run.serviceAgent" "roles/cloudasset.viewer" "roles/logging.viewer" "roles/securitycenter.adminViewer")
+declare -a ROLES=(
+    "roles/iam.workloadIdentityUser" 
+    "roles/iam.serviceAccountUser"  
+    "roles/run.invoker" 
+    "roles/run.serviceAgent" 
+    "roles/cloudasset.viewer" 
+    "roles/logging.viewer" 
+    "roles/securitycenter.adminViewer"
+    "projects/$PROJECT_ID/roles/cac_storage_role" #storage.admin
+    "projects/$PROJECT_ID/roles/cac_scheduler_role"  #cloudscheduler.admin
+    "projects/$PROJECT_ID/roles/cac_run_role" #run.developer
+)
+
+
 ROLE_COUNT=$(echo "${ROLES[@]}" | wc -w)
 # Declare cloud run service name
 CLOUD_RUN="compliance-analysis"
@@ -15,6 +28,7 @@ LOG_FILE="deployment-setup.log"
 SCHEDULE="0 0 * * *"
 LOG_LEVEL="INFO"
 DATE=$(date)
+
 function clean_up {
   # Find and delete all directories starting with "guardrail" in the current working directory
   for dir in $(find . -type d -name "guardrail-*"); do
@@ -23,6 +37,7 @@ function clean_up {
     echo "Deleted $dir"
   done
 }
+
 function input_language {
   ## Allows user to set preferred install language.
   read -p " 
@@ -58,7 +73,32 @@ function config_init {
 
   ## Gathers required information for installation
   printf "$LANG_SETUP_PROMPT"
+<<<<<<< HEAD
   REQUIRED_VARIABLES=("PROJECT_ID" "SERVICE_ACCOUNT" "ORG_NAME" "GC_PROFILE" "SECURITY_CATEGORY_KEY" "PRIVILEGED_USERS_LIST" "REGULAR_USERS_LIST" "ALLOWED_DOMAINS" "DENY_DOMAINS" "HAS_GUEST_USERS" "HAS_FEDERATED_USERS" "ALLOWED_IPS" "CUSTOMER_IDS" "CA_ISSUERS" "ORG_ADMIN_GROUP_EMAIL" "BREAKGLASS_USER_EMAILS" "SSC_BUCKET_NAME" "POLICY_REPO" "OPA_IMAGE" "REGION")
+=======
+  REQUIRED_VARIABLES=(
+      "PROJECT_ID"
+      "SERVICE_ACCOUNT" 
+      "ORG_NAME" 
+      "GC_PROFILE" 
+      "SECURITY_CATEGORY_KEY" 
+      "PRIVILEGED_USERS_LIST" 
+      "REGULAR_USERS_LIST" 
+      "ALLOWED_DOMAINS" 
+      "DENY_DOMAINS" 
+      "HAS_GUEST_USERS" 
+      "HAS_FEDERATED_USERS" 
+      "ALLOWED_IPS" 
+      "CUSTOMER_IDS" 
+      "CA_ISSUERS" 
+      "ORG_ADMIN_GROUP_EMAIL" 
+      "BREAKGLASS_USER_EMAIL" 
+      "SSC_BUCKET_NAME" 
+      "POLICY_REPO" 
+      "OPA_IMAGE" 
+      "REGION"
+  )
+>>>>>>> update-iam-roles
 
   for setting in "${REQUIRED_VARIABLES[@]}"; do
     if [[ "$setting" == "ALLOWED_IPS" && $HAS_FEDERATED_USERS == "true" ]]; then
@@ -102,7 +142,7 @@ function service_account {
   echo $BINDING_PROMPT 2> >(tee -a "$LOG_FILE" | grep -v -i "warning" >&2)
   gcloud iam service-accounts add-iam-policy-binding $SERVICE_ACCOUNT \
     --member="user:$(gcloud config list account --format "value(core.account)")" \
-    --role="roles/iam.serviceAccountTokenCreator" 2> >(tee -a "$LOG_FILE" | grep -v -i "warning" >&2)1
+    --role="roles/iam.serviceAccountTokenCreator" 2> >(tee -a "$LOG_FILE" | grep -v -i "warning" >&2)
 
 }
 
@@ -141,20 +181,25 @@ function storage_bucket {
 
   # Set the IAM policy for the bucket
   API_ROLES=("legacyBucketReader" "objectViewer" "legacyBucketWriter")
+  
   for role in ${API_ROLES[@]}; do
     gsutil --impersonate-service-account="$SERVICE_ACCOUNT" iam ch \
       serviceAccount:project-$PROJECT_NUMBER@storage-transfer-service.iam.gserviceaccount.com:${role} \
       gs://${BUCKET_NAME} 2> >(tee -a "$LOG_FILE" | grep -v -i "warning" >&2)
   done
+    
+  # gsutil doesn't allow setting IAM policies with custom roles - changed to gcloud command
+  gcloud storage buckets add-iam-policy-binding gs://${BUCKET_NAME} \
+    --member=serviceAccount:service-$PROJECT_NUMBER@gcp-sa-cloudasset.iam.gserviceaccount.com \
+    --role=projects/$PROJECT_ID/roles/cac_storage_object_role \
+    --impersonate-service-account="$SERVICE_ACCOUNT" \
+    2> >(tee -a "$LOG_FILE" | grep -v -i "warning" >&2)
 
-  gsutil --impersonate-service-account="$SERVICE_ACCOUNT" iam ch \
-    serviceAccount:service-$PROJECT_NUMBER@gcp-sa-cloudasset.iam.gserviceaccount.com:objectAdmin \
-    gs://${BUCKET_NAME} 2> >(tee -a "$LOG_FILE" | grep -v -i "warning" >&2)
 
   RUN_HOUR="02:00:00-04:00"
   ORDINAL=$((($RANDOM % 10 + 1)))
 
-  # Set up cloud storage transfer job
+  Set up cloud storage transfer job
   gcloud transfer jobs list --job-statuses=enabled | grep nightly_compliance_transfer >/dev/null 2>&1
   ret=$?
   if [ $ret -ne 0 ]; then
@@ -164,7 +209,7 @@ function storage_bucket {
       --schedule-starts=$(date -d "+1day" -u +"%Y-%m-%dT${RUN_HOUR}") \
       --schedule-repeats-every=p1d
   fi
-}
+ }
 
 function cloudrun_service {
 

--- a/project_setup/custom_roles/cac-run-role.yaml
+++ b/project_setup/custom_roles/cac-run-role.yaml
@@ -1,0 +1,10 @@
+title: "CaC Run Role"
+description: "Custom role for CaC solution Cloud Run operations"
+stage: "GA"
+includedPermissions:
+  - run.services.create
+  - run.services.get
+  - run.services.list
+  - run.services.update
+  - run.revisions.get
+  - run.revisions.list

--- a/project_setup/custom_roles/cac-scheduler-role.yaml
+++ b/project_setup/custom_roles/cac-scheduler-role.yaml
@@ -1,0 +1,5 @@
+title: "CaC Scheduler Role"  
+description: "Custom role for CaC solution Cloud Scheduler operations"
+stage: "GA"
+includedPermissions:
+   - cloudscheduler.jobs.create

--- a/project_setup/custom_roles/cac-storage-object-role.yaml
+++ b/project_setup/custom_roles/cac-storage-object-role.yaml
@@ -1,0 +1,10 @@
+title: "CaC Storage Object Role"
+description: "Custom role for CaC solution Cloud Storage Objects operations"
+stage: "GA"
+includedPermissions:
+  - storage.objects.create
+  - storage.objects.get
+  - storage.objects.list
+  - storage.objects.update
+  - storage.objects.getIamPolicy
+  - storage.objects.setIamPolicy

--- a/project_setup/custom_roles/cac-storage-role.yaml
+++ b/project_setup/custom_roles/cac-storage-role.yaml
@@ -1,0 +1,16 @@
+title: "CaC Storage Role"
+description: "Custom role for CaC solution Cloud Storage operations"
+stage: "GA"
+includedPermissions:
+  - storage.buckets.create
+  - storage.buckets.get
+  - storage.buckets.list
+  - storage.buckets.update
+  - storage.buckets.getIamPolicy
+  - storage.buckets.setIamPolicy
+  - storage.objects.create
+  - storage.objects.get
+  - storage.objects.list
+  - storage.objects.update
+  - storage.objects.getIamPolicy
+  - storage.objects.setIamPolicy

--- a/project_setup/project_prep.sh
+++ b/project_setup/project_prep.sh
@@ -12,11 +12,60 @@ DATE=$(date)
 PROJECT_ID="$(gcloud config get-value project)"
 PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)" 2>&1)
 
-PROJECT_ROLES=("iam.workloadIdentityUser" "run.developer" "iam.serviceAccountUser" "storage.admin" "cloudscheduler.admin" "run.invoker" "run.serviceAgent")
-ORG_ROLES=("securitycenter.adminViewer" "logging.viewer" "cloudasset.viewer" "essentialcontacts.viewer" "certificatemanager.viewer" "accesscontextmanager.policyReader" "accesscontextmanager.gcpAccessReader")
+CUSTOM_ROLES_DIR="./custom_roles"
 
-SERVICE_APIS=("run" "storagetransfer" "cloudasset")
-PROJECT_APIS=("run" "cloudscheduler" "storage" "cloudasset" "storagetransfer" "securitycenter" "containerregistry" "admin" "cloudidentity" "cloudresourcemanager" "orgpolicy" "accesscontextmanager" "certificatemanager" "essentialcontacts" )
+CUSTOM_PROJECT_ROLES_FILES=(
+    "cac-storage-role" 
+    "cac-storage-object-role"
+    "cac-scheduler-role" 
+    "cac-run-role"
+)
+
+PROJECT_ROLES=(
+    "iam.workloadIdentityUser" 
+    "iam.serviceAccountUser" 
+    "run.invoker" 
+    "run.serviceAgent"
+)
+
+CUSTOM_PROJECT_ROLES=(
+    "projects/$PROJECT_ID/roles/cac_storage_role" #storage.admin
+    "projects/$PROJECT_ID/roles/cac_scheduler_role"  #cloudscheduler.admin
+    "projects/$PROJECT_ID/roles/cac_run_role" #run.developer
+)
+
+ORG_ROLES=(
+    "securitycenter.adminViewer" 
+    "logging.viewer" 
+    "cloudasset.viewer" 
+    "essentialcontacts.viewer" 
+    "certificatemanager.viewer" 
+    "accesscontextmanager.policyReader" 
+    "accesscontextmanager.gcpAccessReader"
+)
+
+SERVICE_APIS=(
+    "run" 
+    "storagetransfer" 
+    "cloudasset"
+)
+
+PROJECT_APIS=(
+    "run" 
+    "cloudscheduler" 
+    "storage" 
+    "cloudasset" 
+    "storagetransfer" 
+    "securitycenter" 
+    "containerregistry" 
+    "admin" 
+    "cloudidentity" 
+    "cloudresourcemanager" 
+    "orgpolicy" 
+    "accesscontextmanager" 
+    "certificatemanager" 
+    "essentialcontacts" 
+)
 
 
 function input_language {
@@ -59,6 +108,7 @@ function config_init {
   echo "$DATE" >$LOG_FILE 2>&1
   echo "$DATE" >$OUTPUT_FILE 2>&1
 }
+
 function enable_apis {
   echo "$LANG_APIS"
   for service in ${PROJECT_APIS[@]}; do
@@ -66,23 +116,62 @@ function enable_apis {
   done
 }
 
+# # TO-DO: Add to english/french files
+LANG_CUSTOM_ROLES="Installing custom roles:"
+LANG_CUSTOM_PROJECT_ROLE_CREATED="Custom project role created:"
+LANG_CUSTOM_PROJECT_ROLE_UPDATED="Custom project role updated:"
+
+
+function create_custom_project_roles {
+  echo "$LANG_CUSTOM_ROLES"
+  
+  for role_file in ${CUSTOM_PROJECT_ROLES_FILES[@]}; do
+    role_id="${role_file//-/_}"  # Convert hyphens to underscores for role ID
+    role_yaml="$CUSTOM_ROLES_DIR/${role_file}.yaml"
+    
+    # Try to create the role first
+    if gcloud iam roles create $role_id \
+       --project=$PROJECT_ID \
+       --file=$role_yaml \
+       --quiet >>$LOG_FILE 2>&1; then
+      echo "$LANG_CUSTOM_PROJECT_ROLE_CREATED $role_id in project $PROJECT_ID"
+    else
+      # If creation failed (likely because role exists) then update it instead
+      gcloud iam roles update $role_id \
+        --project=$PROJECT_ID \
+        --file=$role_yaml \
+        --quiet >>$LOG_FILE 2>&1
+      echo "$LANG_CUSTOM_PROJECT_ROLE_UPDATED $role_id in project $PROJECT_ID"
+    fi
+    
+  done
+}
+
+
 function service_account_setup {
   SERVICE_ACCOUNT="cac-solution-${ORG_ID}-sa"
   gcloud iam service-accounts create ${SERVICE_ACCOUNT} \
     --description="CaC Solution Service Account" >>$LOG_FILE 2>&1
 
   echo "$LANG_SA_SETUP"
-  for role in ${PROJECT_ROLES[@]}; do
-    gcloud projects add-iam-policy-binding ${PROJECT_ID} \
-      --member=serviceAccount:$SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com \
-      --role=roles/${role}>>$LOG_FILE 2>&1
-  done
-
-  for role in ${ORG_ROLES[@]}; do
-    gcloud organizations add-iam-policy-binding $ORG_ID \
-      --member=serviceAccount:$SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com --condition=None \
-      --role=roles/${role}>>$LOG_FILE 2>&1
-  done
+  
+    for role in ${PROJECT_ROLES[@]}; do
+        gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+        --member=serviceAccount:$SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com \
+        --role=roles/${role}>>$LOG_FILE 2>&1
+    done
+  
+    for role in ${CUSTOM_PROJECT_ROLES[@]}; do
+        gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+        --member=serviceAccount:$SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com \
+        --role=${role}>>$LOG_FILE 2>&1
+    done
+    
+    for role in ${ORG_ROLES[@]}; do
+        gcloud organizations add-iam-policy-binding $ORG_ID \
+        --member=serviceAccount:$SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com --condition=None \
+        --role=roles/${role}>>$LOG_FILE 2>&1
+    done
 }
 
 function service_identities_create {
@@ -94,16 +183,17 @@ function service_identities_create {
   gcloud projects add-iam-policy-binding ${PROJECT_ID} \
     --member=serviceAccount:project-$PROJECT_NUMBER@storage-transfer-service.iam.gserviceaccount.com \
     --role=roles/storage.objectViewer>>$LOG_FILE 2>&1
+    
   gcloud projects add-iam-policy-binding ${PROJECT_ID} \
     --member=serviceAccount:service-$PROJECT_NUMBER@gcp-sa-cloudasset.iam.gserviceaccount.com \
-    --role=roles/storage.objectAdmin >>$LOG_FILE 2>&1
+    --role=projects/$PROJECT_ID/roles/cac_storage_object_role >>$LOG_FILE 2>&1 # storage.objectAdmin
 }
 
 input_language
 config_init
 enable_apis
+create_custom_project_roles
 service_account_setup
-
 service_identities_create
 
 echo "
@@ -113,7 +203,7 @@ echo "
 ## Service Account Information for SSC:
 ##
 ## Compliance Tool Service Account: 
-## $SERVICE_ACCOUNT
+## $SERVICE_ACCOUNT$PROJECT_ID.iam.gserviceaccount.com
 ##
 ## CloudRun Robot Account: 
 ## service-$PROJECT_NUMBER@serverless-robot-prod.iam.gserviceaccount.com


### PR DESCRIPTION
This PR includes fixes to the setup scripts so that we can use custom roles and hand pick the permissions required, as opposed to the overly permissive pre-defined roles that exist in GCP.