### PR TITLE
Fix OPA timeout & move ORG_ID to configuration file

### DIFF
--- a/collect_setup/collector_config.sample
+++ b/collect_setup/collector_config.sample
@@ -59,7 +59,8 @@ export CUSTOMER_IDS='C012habcde'
 # Format: "Let's Encrypt,Verisign"
 export CA_ISSUERS="Let's Encrypt,Verisign"
 
-# GR11.4
+# GCP Organization ID
+# run `gcloud organizations list` to find yours
 export ORG_ID="1234567890"
 
 #GR13.2 & GR13.3

--- a/collect_setup/functions.sh
+++ b/collect_setup/functions.sh
@@ -331,7 +331,7 @@ function cloudrun_service {
                     cd /mnt/policies
                     git checkout ${BRANCH}
                     ls -l /mnt/policies
-                    /usr/bin/opa run --server --h2c --addr :8181 --log-level debug --disable-telemetry --set server.decoding.max_length=536870912 --set server.decoding.gzip.max_length=1073741824 /mnt/policies
+                    /usr/bin/opa run --server --h2c --addr :8181 --log-level debug --disable-telemetry --set server.decoding.max_length=1073741824 --set server.decoding.gzip.max_length=1073741824 /mnt/policies
                 env:
                 - name: GC_PROFILE
                   value: "${GC_PROFILE}"

--- a/collect_setup/functions.sh
+++ b/collect_setup/functions.sh
@@ -45,6 +45,7 @@ function config_init {
       "PROJECT_ID"
       "SERVICE_ACCOUNT"
       "ORG_NAME"
+      "ORG_ID"
       "GC_PROFILE"
       "SECURITY_CATEGORY_KEY"
       "PRIVILEGED_USERS_LIST"
@@ -81,7 +82,6 @@ function config_init {
   fi
 
   PROJECT_NUMBER=$(gcloud projects describe "${PROJECT_ID}" --format="value(projectNumber)" 2>&1)
-  ORG_ID="$(gcloud organizations list --filter="${ORG_NAME}" --format="value(ID)" 2>&1)"
   ACCOUNT_NUMBER=$(gcloud projects describe "${PROJECT_ID}" --format="value(projectNumber)" 2>&1)
   JOB_NAME="compliance-analysis-automation-$(echo "${ACCOUNT_NUMBER}" | tr '[:upper:]' '[:lower:]')"
   BUCKET_NAME="compliance-hub-"$(echo ${ACCOUNT_NUMBER} | tr '[:upper:]' '[:lower:]')
@@ -494,7 +494,8 @@ function generate_collector_config() {
   # List of Acceptable Certifcate Authorities
   # Format: "Let's Encrypt,Verisign"
   export CA_ISSUERS="${CA_ISSUERS}"
-  # GR11.4
+  # GCP Organization ID
+  # run `gcloud organizations list` to find yours
   export ORG_ID="${ORG_ID}"
   #GR13.2 & GR13.3
   # breakglass user emails


### PR DESCRIPTION
This PR has bumped the OPA file limit to 1 GB, as well as moved the ORG_ID variable to be grabbed from the configuration file, as opposed to grabbed automatically.