### PR TITLE
Adding binaryauthorization.policyEditor role to CaC Service Account

### DIFF
--- a/project_setup/functions.sh
+++ b/project_setup/functions.sh
@@ -218,6 +218,7 @@ function service_account_setup {
     "iam.serviceAccountUser"
     "run.invoker"
     "run.serviceAgent"
+    "binaryauthorization.policyEditor"
   )
 
   OLD_PROJECT_ROLES=(


### PR DESCRIPTION
Adding the `binaryauthorization.policyEditor` role to the CaC service account for setting up BinAuthz policy.