### PR TITLE
Added --skip-version-check argument for OPA; safe directory for non-root container

### DIFF
--- a/collect_setup/functions.sh
+++ b/collect_setup/functions.sh
@@ -327,11 +327,12 @@ function cloudrun_service {
                   - |
                     rm -Rf /mnt/policies/*
                     git config --global credential.helper gcloud.sh
+                    git config --global --add safe.directory /mnt/policies
                     git clone --quiet ${POLICY_REPO} /mnt/policies
                     cd /mnt/policies
                     git checkout ${BRANCH}
                     ls -l /mnt/policies
-                    /usr/bin/opa run --server --h2c --addr :8181 --log-level debug --disable-telemetry --set server.decoding.max_length=1073741824 --set server.decoding.gzip.max_length=1073741824 /mnt/policies
+                    /usr/bin/opa run --server --h2c --addr :8181 --log-level debug --skip-version-check --set server.decoding.max_length=1073741824 --set server.decoding.gzip.max_length=1073741824 /mnt/policies
                 env:
                 - name: GC_PROFILE
                   value: "${GC_PROFILE}"


### PR DESCRIPTION
`--disable-telemetry` has been deprecated, so replaced it with `--skip-version-check`

Added a config to git to ensure that it trusts the `/mnt/policies/ directory, as the container will now be running as non-root.