### PR TITLE
Change logging.viewer to logging.privateLogViewer

### DIFF
--- a/project_setup/functions.sh
+++ b/project_setup/functions.sh
@@ -229,7 +229,7 @@ function service_account_setup {
 
   ORG_ROLES=(
     "securitycenter.adminViewer"
-    "logging.viewer"
+    "logging.privateLogViewer"
     "cloudasset.viewer"
     "essentialcontacts.viewer"
     "certificatemanager.viewer"


### PR DESCRIPTION
Change is required so that the data access logs for breakglass account can be read.